### PR TITLE
fix: fix for multi-line edit box displaying no text due to protected strings

### DIFF
--- a/ChatFramePlus.toc
+++ b/ChatFramePlus.toc
@@ -23,7 +23,9 @@ Constants\Tab.lua
 
 # Utils
 Utils\ChatFrame.lua
+Utils\Color.lua
 Utils\Database.lua
+Utils\Message.lua
 Utils\String.lua
 Utils\Trie.lua
 

--- a/Hooks/ChatFrame.lua
+++ b/Hooks/ChatFrame.lua
@@ -56,7 +56,7 @@ local function handleTabOnClick(chatTab, button)
 		local databaseCopy = DatabaseUtils.GetChatFramesTable(chatFrameId, "copy")
 
 		if databaseCopy.isEnabled then
-			CopyModule:ShowCopyFrame(chatFrame)
+			CopyModule:Show(chatFrame)
 		else
 			chatFrame:AddMessage(
 				string.format("Copy is disabled for %s. Please enable it in the options.", chatTabName)

--- a/Utils/ChatFrame.lua
+++ b/Utils/ChatFrame.lua
@@ -10,9 +10,7 @@ function ChatFrameUtils:ForEachChatFrame(callback)
 	for index = 1, NUM_CHAT_WINDOWS do
 		local chatFrame = self:GetChatFrame(index)
 
-		if chatFrame then
-			callback(chatFrame, index)
-		end
+		callback(chatFrame, index)
 	end
 end
 
@@ -23,11 +21,9 @@ function ChatFrameUtils:ForEachChatFrameMessage(chatFrame, callback)
 	local numMessages = chatFrame:GetNumMessages()
 
 	for index = 1, numMessages do
-		local message = chatFrame:GetMessageInfo(index)
+		local text, r, g, b = chatFrame:GetMessageInfo(index)
 
-		if message then
-			callback(message, index)
-		end
+		callback(text, r, g, b)
 	end
 end
 
@@ -50,19 +46,6 @@ end
 --- @return number
 function ChatFrameUtils:GetChatFrameId(chatFrame)
 	return chatFrame and chatFrame:GetID()
-end
-
---- Returns a table of chat frame messages e.g. { "a", "b" }
---- @param chatFrame table
---- @return table
-function ChatFrameUtils:GetChatFrameMessages(chatFrame)
-	local messages = {}
-
-	self:ForEachChatFrameMessage(chatFrame, function(message)
-		table.insert(messages, message)
-	end)
-
-	return messages
 end
 
 --- Returns a chat frame name e.g. ChatFrame1

--- a/Utils/Color.lua
+++ b/Utils/Color.lua
@@ -1,0 +1,20 @@
+--- @class Private
+local Private = select(2, ...)
+
+--- @class ColorUtils
+local ColorUtils = {}
+
+--- Returns a hex color string from RGB values.
+--- @param r number
+--- @param g number
+--- @param b number
+--- @return string
+function ColorUtils.RGBToHex(r, g, b)
+	if r and g and b then
+		return string.format("|cff%02x%02x%02x", r * 255, g * 255, b * 255)
+	else
+		return "|cffffffff"
+	end
+end
+
+Private.ColorUtils = ColorUtils

--- a/Utils/Message.lua
+++ b/Utils/Message.lua
@@ -1,0 +1,24 @@
+--- @class Private
+local Private = select(2, ...)
+
+--- @class MessageUtils
+local MessageUtils = {}
+
+--- Returns the protected id if the provided string is empty.
+--- @param potentialProtectedString string
+--- @param fallbackId string
+--- @return string?
+local function extractProtectedId(potentialProtectedString, fallbackId)
+	if fallbackId and potentialProtectedString == "" then
+		return fallbackId
+	end
+end
+
+--- Returns true if the message is protected.
+--- @param message string
+--- @return boolean
+function MessageUtils.IsMessageProtected(message)
+	return message and (message ~= gsub(message, "(:?|?)|K(.-)|k", extractProtectedId))
+end
+
+Private.MessageUtils = MessageUtils


### PR DESCRIPTION
fix: fix for multi-line edit box displaying no text due to protected strings

If there is a single protected string in a chat frame (such as a Battle.net friend going online or offline), it causes no text to be inserted into the multi-line edit box.

issue #2