### PR TITLE
feat: initial button module functionality

### DIFF
--- a/ChatFramePlus.toc
+++ b/ChatFramePlus.toc
@@ -31,6 +31,7 @@ Utils\Trie.lua
 
 # Modules
 Modules\Border.lua
+Modules\Button.lua
 Modules\Copy.lua
 Modules\Filter.lua
 Modules\Font.lua
@@ -46,6 +47,7 @@ Core\Database.lua
 # Options
 Options\Options.lua
 Options\Border.lua
+Options\Button.lua
 Options\Copy.lua
 Options\Filter.lua
 Options\Font.lua

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -19,6 +19,7 @@ end
 
 function Addon:OnEnable()
 	Addon:EnableModule("Border")
+	Addon:EnableModule("Button")
 	Addon:EnableModule("Filter")
 	Addon:EnableModule("Font")
 	Addon:EnableModule("Tab")

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -18,6 +18,16 @@ local borderDefaultsForChatFrame = {
 	isEnabled = false,
 }
 
+--- @class buttonDefaultsForChatFrame
+--- @field isBottomButtonVisible boolean
+--- @field isDownButtonVisible boolean
+--- @field isUpButtonVisible boolean
+local buttonDefaultsForChatFrame = {
+	isBottomButtonVisible = true,
+	isDownButtonVisible = true,
+	isUpButtonVisible = true,
+}
+
 --- @class copyDefaultsForChatFrame
 --- @field isEnabled boolean
 local copyDefaultsForChatFrame = {
@@ -67,6 +77,7 @@ function Private:GetDatabaseDefaults()
 	ChatFrameUtils:ForEachChatFrame(function(_, index)
 		database.profile.chatFrames[index] = {
 			border = borderDefaultsForChatFrame,
+			button = buttonDefaultsForChatFrame,
 			copy = copyDefaultsForChatFrame,
 			filter = filterDefaultsForChatFrame,
 			font = fontDefaultsForChatFrame,

--- a/Modules/Button.lua
+++ b/Modules/Button.lua
@@ -1,0 +1,38 @@
+--- @class Private
+local Private = select(2, ...)
+
+--- @class ButtonModule: AceModule
+local ButtonModule = Private.Addon:NewModule("Button")
+
+--- @class ChatFrameUtils
+local ChatFrameUtils = Private.ChatFrameUtils
+
+--- @class DatabaseUtils
+local DatabaseUtils = Private.DatabaseUtils
+
+--- Update the button properties for a chat frame.
+--- @param chatFrame table
+function ButtonModule:UpdateButtonVisibility(chatFrame)
+	local chatFrameId = ChatFrameUtils:GetChatFrameId(chatFrame)
+	local databaseButton = DatabaseUtils.GetChatFramesTable(chatFrameId, "button")
+
+	local buttonMap = {
+		isBottomButtonVisible = chatFrame.buttonFrame.bottomButton,
+		isDownButtonVisible = chatFrame.buttonFrame.downButton,
+		isUpButtonVisible = chatFrame.buttonFrame.upButton,
+	}
+
+	for isVisible, button in pairs(buttonMap) do
+		if databaseButton[isVisible] then
+			button:Show()
+		else
+			button:Hide()
+		end
+	end
+end
+
+function ButtonModule:OnEnable()
+	ChatFrameUtils:ForEachChatFrame(function(chatFrame)
+		self:UpdateButtonVisibility(chatFrame)
+	end)
+end

--- a/Options/Button.lua
+++ b/Options/Button.lua
@@ -1,0 +1,83 @@
+--- @class Private
+local Private = select(2, ...)
+
+--- @class ButtonOptions
+local ButtonOptions = {}
+
+--- @class ButtonModule: AceModule
+local ButtonModule = Private.Addon:GetModule("Button")
+
+--- @class DatabaseUtils
+local DatabaseUtils = Private.DatabaseUtils
+
+--- Returns the button options table for a chat frame.
+--- @param chatFrame table
+--- @param index number
+--- @return table
+function ButtonOptions:CreateOptionsTableForChatFrame(chatFrame, index)
+	local databaseButton = DatabaseUtils.GetChatFramesTable(index, "button")
+
+	return {
+		order = 2,
+		type = "group",
+		name = ButtonModule.moduleName,
+		desc = "Button options",
+		args = {
+			buttonTogglesGroup = {
+				order = 1,
+				type = "group",
+				name = "Button Toggles",
+				inline = true,
+				args = {
+					bottomButtonIsVisible = {
+						order = 1,
+						type = "toggle",
+						name = "Bottom Button Visible",
+						desc = "Toggle the visibility of the bottom button",
+						width = "full",
+						get = function()
+							return databaseButton.isBottomButtonVisible
+						end,
+						set = function(_, value)
+							databaseButton.isBottomButtonVisible = value
+
+							ButtonModule:UpdateButtonVisibility(chatFrame)
+						end,
+					},
+					downButtonIsVisible = {
+						order = 2,
+						type = "toggle",
+						name = "Down Button Visible",
+						desc = "Toggle the visibility of the down button",
+						width = "full",
+						get = function()
+							return databaseButton.isDownButtonVisible
+						end,
+						set = function(_, value)
+							databaseButton.isDownButtonVisible = value
+
+							ButtonModule:UpdateButtonVisibility(chatFrame)
+						end,
+					},
+					upButtonIsVisible = {
+						order = 3,
+						type = "toggle",
+						name = "Up Button Visible",
+						desc = "Toggle the visibility of the up button",
+						width = "full",
+						get = function()
+							return databaseButton.isUpButtonVisible
+						end,
+						set = function(_, value)
+							databaseButton.isUpButtonVisible = value
+
+							ButtonModule:UpdateButtonVisibility(chatFrame)
+						end,
+					},
+				},
+			},
+		},
+	}
+end
+
+Private.ButtonOptions = ButtonOptions

--- a/Options/Copy.lua
+++ b/Options/Copy.lua
@@ -18,7 +18,7 @@ function CopyOptions:CreateOptionsTableForChatFrame(chatFrame, index)
 	local databaseCopy = DatabaseUtils.GetChatFramesTable(index, "copy")
 
 	return {
-		order = 2,
+		order = 3,
 		type = "group",
 		name = CopyModule.moduleName,
 		desc = "Copy options",

--- a/Options/Filter.lua
+++ b/Options/Filter.lua
@@ -30,7 +30,7 @@ function FilterOptions:CreateOptionsTableForChatFrame(chatFrame, index)
 	local databaseFilter = DatabaseUtils.GetChatFramesTable(index, "filter")
 
 	return {
-		order = 3,
+		order = 4,
 		type = "group",
 		childGroups = "tab",
 		name = FilterModule.moduleName,

--- a/Options/Font.lua
+++ b/Options/Font.lua
@@ -21,7 +21,7 @@ function FontOptions:CreateOptionsTableForChatFrame(chatFrame, index)
 	local databaseFont = DatabaseUtils.GetChatFramesTable(index, "font")
 
 	return {
-		order = 4,
+		order = 5,
 		type = "group",
 		name = FontModule.moduleName,
 		desc = "Font options",

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -19,6 +19,7 @@ local ChatFrameUtils = Private.ChatFrameUtils
 --- @return table
 local function createOptionsTableForChatFrame(chatFrame, index)
 	local BorderOptions = Private.BorderOptions
+	local ButtonOptions = Private.ButtonOptions
 	local CopyOptions = Private.CopyOptions
 	local FilterOptions = Private.FilterOptions
 	local FontOptions = Private.FontOptions
@@ -26,6 +27,7 @@ local function createOptionsTableForChatFrame(chatFrame, index)
 
 	return {
 		border = BorderOptions:CreateOptionsTableForChatFrame(chatFrame, index),
+		button = ButtonOptions:CreateOptionsTableForChatFrame(chatFrame, index),
 		copy = CopyOptions:CreateOptionsTableForChatFrame(chatFrame, index),
 		filter = FilterOptions:CreateOptionsTableForChatFrame(chatFrame, index),
 		font = FontOptions:CreateOptionsTableForChatFrame(chatFrame, index),

--- a/Options/Tab.lua
+++ b/Options/Tab.lua
@@ -21,7 +21,7 @@ function TabOptions:CreateOptionsTableForChatFrame(chatFrame, index)
 	local databaseTab = DatabaseUtils.GetChatFramesTable(index, "tab")
 
 	return {
-		order = 5,
+		order = 6,
 		type = "group",
 		name = TabModule.moduleName,
 		desc = "Tab options",


### PR DESCRIPTION
Need to think more about how to structure functionality specific to a chat frame versus functionality for the entire chat frame. Initial button module will allow players to show or hide the navigational buttons as they are specific to a chat frame. That is how the addon functions currently, so it's easy to implement this slice.