### PR TITLE
fix(db): invalid database index error dependent on New Whispers option

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -12,7 +12,7 @@ local ChatFrameHooks = Private.ChatFrameHooks
 
 function Addon:OnInitialize()
 	--- @class AceDBObject-3.0
-	Private.db = LibStub("AceDB-3.0"):New(AddonName .. "DB", Private:GetDatabaseDefaults(), true)
+	Private.db = LibStub("AceDB-3.0"):New(AddonName .. "DB", Private.Database:GetDatabaseDefaults(), true)
 
 	Private.Options:Initialize()
 end

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -1,6 +1,9 @@
 --- @class Private
 local Private = select(2, ...)
 
+--- @class Database
+local Database = {}
+
 --- @class ChatFrameUtils
 local ChatFrameUtils = Private.ChatFrameUtils
 
@@ -90,9 +93,23 @@ local tabDefaultsForChatFrame = {
 	isBackgroundVisible = true,
 }
 
+--- Get the database defaults for a chat frame.
+--- @return table
+function Database.GetChatFrameDefaults()
+	return {
+		background = backgroundDefaultsForChatFrame,
+		border = borderDefaultsForChatFrame,
+		button = buttonDefaultsForChatFrame,
+		copy = copyDefaultsForChatFrame,
+		filter = filterDefaultsForChatFrame,
+		font = fontDefaultsForChatFrame,
+		tab = tabDefaultsForChatFrame,
+	}
+end
+
 --- Get the database defaults.
 --- @return AceDBObject-3.0
-function Private:GetDatabaseDefaults()
+function Database:GetDatabaseDefaults()
 	--- @class AceDBObject-3.0
 	local database = {
 		profile = {
@@ -105,16 +122,10 @@ function Private:GetDatabaseDefaults()
 	}
 
 	ChatFrameUtils:ForEachChatFrame(function(_, index)
-		database.profile.chatFrames[index] = {
-			background = backgroundDefaultsForChatFrame,
-			border = borderDefaultsForChatFrame,
-			button = buttonDefaultsForChatFrame,
-			copy = copyDefaultsForChatFrame,
-			filter = filterDefaultsForChatFrame,
-			font = fontDefaultsForChatFrame,
-			tab = tabDefaultsForChatFrame,
-		}
+		database.profile.chatFrames[index] = self:GetChatFrameDefaults()
 	end)
 
 	return database
 end
+
+Private.Database = Database

--- a/Utils/Database.lua
+++ b/Utils/Database.lua
@@ -21,6 +21,10 @@ function DatabaseUtils.GetChatFramesTable(index, key)
 	assert(type(index) == "number", "bad argument #1 expected number got " .. type(index))
 	assert(type(key) == "string", "bad argument #2 expected string got " .. type(key))
 
+	if not Private.db.profile.chatFrames[index] then
+		Private.db.profile.chatFrames[index] = Private.Database.GetChatFrameDefaults()
+	end
+
 	return Private.db.profile.chatFrames[index][key]
 end
 


### PR DESCRIPTION
If a user sets the option New Whispers to Both or New Tab and receives or sends a whisper, a new chat frame is created. No table in the database exists for the new chat frame because a table is only created for the chat frames that exist when the addon first loads. This fix creates a table in the database for new chat frames when GetChatFramesTable gets called.

issue #15